### PR TITLE
gp2=>gp3

### DIFF
--- a/files/exampleFleet_us-east-1.json
+++ b/files/exampleFleet_us-east-1.json
@@ -14,7 +14,7 @@
           "DeviceName": "/dev/xvda",
           "Ebs": {
             "DeleteOnTermination": true,
-            "VolumeType": "gp2",
+            "VolumeType": "gp3",
             "VolumeSize": 8,
             "SnapshotId": "snap-0a7b4ece894d62882"
           }
@@ -23,7 +23,7 @@
           "DeviceName": "/dev/xvdcz",
           "Ebs": {
             "DeleteOnTermination": true,
-            "VolumeType": "gp2"
+            "VolumeType": "gp3"
           }
         }
       ],


### PR DESCRIPTION
AWS is now recommending gp3 as default for reasons including reduced price and increased availability