### PR TITLE
bypass S3FS if downloading

### DIFF
--- a/worker/run-worker.sh
+++ b/worker/run-worker.sh
@@ -23,15 +23,17 @@ VOL_1_ID=$(aws ec2 describe-instance-attribute --instance-id $MY_INSTANCE_ID --a
 aws ec2 create-tags --resources $VOL_1_ID --tags Key=Name,Value=${APP_NAME}Worker
 
 # 2. MOUNT S3 
-echo "Mounting S3 using S3FS"
-if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
-    echo "Using role credentials to mount S3"
-    s3fs $SOURCE_BUCKET /home/ubuntu/bucket -o iam_role
-else
-    echo "Using user credentials to mount S3"
-    echo $AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY > /credentials.txt
-    chmod 600 /credentials.txt
-    s3fs $SOURCE_BUCKET /home/ubuntu/bucket -o passwd_file=/credentials.txt
+if [[ ${DOWNLOAD_FILES} == 'False' ]]; then
+  echo "Mounting S3 using S3FS"
+  if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
+      echo "Using role credentials to mount S3"
+      s3fs $SOURCE_BUCKET /home/ubuntu/bucket -o iam_role
+  else
+      echo "Using user credentials to mount S3"
+      echo $AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY > /credentials.txt
+      chmod 600 /credentials.txt
+      s3fs $SOURCE_BUCKET /home/ubuntu/bucket -o passwd_file=/credentials.txt
+  fi
 fi
 
 # 3. SET UP ALARMS


### PR DESCRIPTION
Was stuck in a situation where I was trying to work off of CPG in `2.2.0_4.2.8` (and `erinweisbart:2.2.0rc1_4.2.4`) and kept getting an error, possibly something to do with mounting. #186 

I haven't tracked down what was causing the error yet, but to get around it by downloading files instead of using S3FS, this change needed to be made to run_worker.py (which it seems should be there regardless to prevent other hypothetical problems because there's no need to try to mount bucket with S3FS if you are downloading your files)