### PR TITLE
Change deleted messages from Average to Sum

### DIFF
--- a/run.py
+++ b/run.py
@@ -365,7 +365,7 @@ def create_dashboard(requestInfo):
                     "stacked": False,
                     "region": AWS_REGION,
                     "period": 300,
-                    "stat": "Average"
+                    "stat": "Sum"
                 }
             },
             {


### PR DESCRIPTION
I'm not sure what the intent of this graph is, fully - if it's only to look for percent errors in messages being deleted or placed, or overall rate of those things happening; if the former, our current setting of "Average" is good, otherwise we might think about "Sum". Please close if "Average" in fact preferred.

First screenshot: sum, second: average

<img width="367" height="294" alt="image" src="https://github.com/user-attachments/assets/cbf75c62-08f9-4dfa-bec2-bbea7e289846" />
<img width="355" height="279" alt="image" src="https://github.com/user-attachments/assets/974ac996-f045-4ef2-859a-afdf7d9abf22" />
